### PR TITLE
feat: Add POLARIS soil texture as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ AgriGEE.lite is organized into three main modules:
 | [ANADEM](https://hge-iph.github.io/anadem/) | Slope, Elevation, Aspect | (single image) | (single image) | South America | 30** | (single image) |  |
 | [Copernicus DEM GLO30](https://developers.google.com/earth-engine/datasets/catalog/COPERNICUS_DEM_GLO30) | Elevation, Slope, Aspect | (single image) | (single image) | Worldwide | 30 | (single image) |  |
 | [SoilGrids classes](https://soilgrids.org/) | WRB Soil Classes (30 categories) | (single image) | (single image) | Worldwide | 250 | (single image) | |
+| POLARIS Soil Texture | Clay, Sand, Silt (0-5 cm), USDA Soil Class (12 categories) | (single image) | (single image) | Continental USA (CONUS) | 30 | (single image) | |
 | Two Satellite Fusion ***** | Intersect common observations from two satellites | (depends on input satellites) | (depends on input satellites) | (depends on input satellites) | (finest of the two satellites) | (depends on input satellites) | |
 
 ### Observations

--- a/agrigee_lite/sat/__init__.py
+++ b/agrigee_lite/sat/__init__.py
@@ -42,7 +42,7 @@ from agrigee_lite.sat.naip import NAIP
 from agrigee_lite.sat.palsar import PALSAR2ScanSAR
 from agrigee_lite.sat.sentinel1 import Sentinel1GRD
 from agrigee_lite.sat.sentinel2 import Sentinel2
-from agrigee_lite.sat.soil import WRBSoilClasses
+from agrigee_lite.sat.soil import PolarisSoilTexture, WRBSoilClasses
 from agrigee_lite.sat.unified_satellite import TwoSatelliteFusion
 
 __all__ = [
@@ -84,6 +84,7 @@ __all__ = [
     "NASADEM",
     "NEONDEM",
     "PALSAR2ScanSAR",
+    "PolarisSoilTexture",
     "REMAMosaic",
     "REMAStrips2m",
     "REMAStrips8m",

--- a/agrigee_lite/sat/soil.py
+++ b/agrigee_lite/sat/soil.py
@@ -118,3 +118,216 @@ class WRBSoilClasses(SingleImageSatellite):
             stats[key] = percentage
 
         return ee.FeatureCollection([ee.Feature(None, stats)])
+
+
+class PolarisSoilTexture(SingleImageSatellite):
+    """POLARIS soil texture — clay/sand/silt content, 0-5 cm depth, 30 m resolution (CONUS only).
+
+    Hosted by sat-io, POLARIS provides probabilistic remapping of SSURGO/
+    STATSGO soil texture at 30 m over the contiguous United States.
+    ``compute()`` returns the mean percent content of the requested texture
+    bands plus, optionally, the fraction of pixels in each of the 12 USDA
+    soil-texture-triangle classes (``usda_soil_class``).
+
+    Parameters
+    ----------
+    bands : list of str, optional
+        Subset of ``["clay", "sand", "silt", "usda_soil_class"]``.  Defaults
+        to all four.
+    border_pixels_to_erode : float, default 1
+        Inward buffer in pixel-widths before extraction.
+    min_area_to_keep_border : int, default 50_000
+        Skip border erosion for geometries smaller than this area (m²).
+
+    Notes
+    -----
+    The ``classes`` attribute maps the 12 USDA soil-texture-triangle class
+    codes to their labels.
+    """
+
+    def __init__(
+        self,
+        bands: list[str] | None = None,
+        border_pixels_to_erode: float = 1,
+        min_area_to_keep_border: int = 50_000,
+    ):
+        if bands is None:
+            bands = ["clay", "sand", "silt", "usda_soil_class"]
+
+        super().__init__()
+
+        self.imageNames: dict[str, str] = {
+            "clay": "projects/sat-io/open-datasets/polaris/clay_mean/clay_0_5",
+            "sand": "projects/sat-io/open-datasets/polaris/sand_mean/sand_0_5",
+            "silt": "projects/sat-io/open-datasets/polaris/silt_mean/silt_0_5",
+        }
+        self.pixelSize: int = 30
+        self.shortName: str = "polaris_soil_texture"
+
+        self.selectedBands: list[tuple[str, str]] = [(band, band) for band in bands]
+
+        self.startDate = "1900-01-01"
+        self.endDate = "2050-01-01"
+        self.minAreaToKeepBorder = min_area_to_keep_border
+        self.borderPixelsToErode = border_pixels_to_erode
+
+        self.classes = {
+            1: "sand",
+            2: "loamy_sand",
+            3: "sandy_loam",
+            4: "loam",
+            5: "silt_loam",
+            6: "silt",
+            7: "sandy_clay_loam",
+            8: "clay_loam",
+            9: "silty_clay_loam",
+            10: "sandy_clay",
+            11: "silty_clay",
+            12: "clay",
+        }
+
+        self.toDownloadSelectors = self._build_to_download_selectors()
+
+    def _build_to_download_selectors(self) -> list[str]:
+        selectors = []
+
+        band_aliases = [alias for _, alias in self.selectedBands]
+
+        if "clay" in band_aliases:
+            selectors += ["40_clay_mean"]
+
+        if "sand" in band_aliases:
+            selectors += ["41_sand_mean"]
+
+        if "silt" in band_aliases:
+            selectors += ["42_silt_mean"]
+
+        if "usda_soil_class" in band_aliases:
+            selectors += [f"{43 + i:02d}_usda_{label}" for i, label in enumerate(self.classes.values())]
+
+        return selectors
+
+    def image(self, ee_feature: ee.Feature) -> ee.Image:
+        clay = ee.Image(self.imageNames["clay"])
+        sand = ee.Image(self.imageNames["sand"])
+        silt = ee.Image(self.imageNames["silt"])
+        composite = ee.Image.cat([clay, sand, silt]).rename(["clay", "sand", "silt"])
+
+        requested_bands = [b for b, _ in self.selectedBands]
+
+        if "usda_soil_class" in requested_bands:
+            usda_soil_class = composite.expression(
+                "(b('silt') + 1.5 * b('clay') < 15) ? 1 : "
+                "(b('silt') + 1.5 * b('clay') >= 15 && b('silt') + 2 * b('clay') < 30) ? 2 : "
+                "(b('clay') >= 7 && b('clay') < 20 && b('sand') > 52 && b('silt') + 2 * b('clay') >= 30) || "
+                "(b('clay') < 7 && b('silt') < 50 && b('silt') + 2 * b('clay') >= 30) ? 3 : "
+                "(b('clay') >= 7 && b('clay') < 27 && b('silt') >= 28 && b('silt') < 50 && b('sand') <= 52) ? 4 : "
+                "(b('silt') >= 50 && b('clay') >= 12 && b('clay') < 27) || "
+                "(b('silt') >= 50 && b('silt') < 80 && b('clay') < 12) ? 5 : "
+                "(b('silt') >= 80 && b('clay') < 12) ? 6 : "
+                "(b('clay') >= 20 && b('clay') < 35 && b('silt') < 28 && b('sand') > 45) ? 7 : "
+                "(b('clay') >= 27 && b('clay') < 40 && b('sand') > 20 && b('sand') <= 45) ? 8 : "
+                "(b('clay') >= 27 && b('clay') < 40 && b('sand') <= 20) ? 9 : "
+                "(b('clay') >= 35 && b('sand') > 45) ? 10 : "
+                "(b('clay') >= 40 && b('silt') >= 40) ? 11 : "
+                "(b('clay') >= 40 && b('sand') <= 45 && b('silt') < 40) ? 12 : 1"
+            ).rename("usda_soil_class")
+            composite = composite.addBands(usda_soil_class)
+
+        selected_band_names = [b for b, _ in self.selectedBands]
+
+        return composite.select(selected_band_names)
+
+    def compute(
+        self,
+        ee_feature: ee.Feature,
+        subsampling_max_pixels: float,
+        reducers: set[str] | None = None,
+    ) -> ee.FeatureCollection:
+        ee_geometry = ee_feature.geometry()
+
+        if self.borderPixelsToErode != 0:
+            ee_geometry = ee_safe_remove_borders(
+                ee_geometry, round(self.borderPixelsToErode * self.pixelSize), self.minAreaToKeepBorder
+            )
+            ee_feature = ee_feature.setGeometry(ee_geometry)
+
+        ee_img = self.image(ee_feature)
+        ee_img = ee_map_valid_pixels(ee_img, ee_geometry, self.pixelSize)
+
+        selected_band_names = [alias for _, alias in self.selectedBands]
+
+        stats_dict = {
+            "00_indexnum": ee_feature.get("0"),
+        }
+
+        # --- Texture percentage means ---
+        for band, prefix in (("clay", "40"), ("sand", "41"), ("silt", "42")):
+            if band in selected_band_names:
+                mean_value = (
+                    ee_img.select(band)
+                    .reduceRegion(
+                        reducer=ee.Reducer.mean(),
+                        geometry=ee_geometry,
+                        scale=self.pixelSize,
+                        maxPixels=int(subsampling_max_pixels),
+                        bestEffort=True,
+                    )
+                    .get(band)
+                )
+                stats_dict[f"{prefix}_{band}_mean"] = mean_value
+
+        # --- USDA soil class breakdown ---
+        if "usda_soil_class" in selected_band_names:
+            usda = ee_img.select("usda_soil_class")
+
+            valid_mask = usda.mask()
+            total_pixels = (
+                ee.Image(1)
+                .updateMask(valid_mask)
+                .reduceRegion(
+                    reducer=ee.Reducer.count(),
+                    geometry=ee_geometry,
+                    scale=self.pixelSize,
+                    maxPixels=int(subsampling_max_pixels),
+                    bestEffort=True,
+                )
+                .getNumber("constant")
+            )
+
+            for i, (class_id, label) in enumerate(self.classes.items()):
+                class_mask = usda.eq(int(class_id))
+
+                count = (
+                    ee.Image(1)
+                    .updateMask(class_mask)
+                    .reduceRegion(
+                        reducer=ee.Reducer.count(),
+                        geometry=ee_geometry,
+                        scale=self.pixelSize,
+                        maxPixels=int(subsampling_max_pixels),
+                        bestEffort=True,
+                    )
+                    .getNumber("constant")
+                )
+
+                percent = ee.Algorithms.If(total_pixels.neq(0), ee.Number(count).divide(total_pixels), 0)
+                stats_dict[f"{43 + i:02d}_usda_{label}"] = percent
+
+        # --- ValidPixelCount ---
+        valid_pixel_count = (
+            ee_img.select(selected_band_names[0])
+            .mask()
+            .reduceRegion(
+                reducer=ee.Reducer.count(),
+                geometry=ee_geometry,
+                scale=self.pixelSize,
+                maxPixels=subsampling_max_pixels,
+                bestEffort=True,
+            )
+            .getNumber(selected_band_names[0])
+        )
+        stats_dict["99_validPixelsCount"] = valid_pixel_count
+
+        stats_feature = ee.Feature(None, stats_dict)
+        return ee.FeatureCollection([stats_feature])

--- a/agrigee_lite/sat/soil.py
+++ b/agrigee_lite/sat/soil.py
@@ -151,11 +151,21 @@ class PolarisSoilTexture(SingleImageSatellite):
         border_pixels_to_erode: float = 1,
         min_area_to_keep_border: int = 50_000,
     ):
+        allowed_bands = {"clay", "sand", "silt", "usda_soil_class"}
+
         if bands is None:
             bands = ["clay", "sand", "silt", "usda_soil_class"]
 
-        super().__init__()
+        if not bands:
+            raise ValueError(f"bands must contain at least one of {sorted(allowed_bands)}")
 
+        invalid = [b for b in bands if b not in allowed_bands]
+        if invalid:
+            raise ValueError(
+                f"Unknown band(s) for PolarisSoilTexture: {invalid}. Valid bands are {sorted(allowed_bands)}"
+            )
+
+        super().__init__
         self.imageNames: dict[str, str] = {
             "clay": "projects/sat-io/open-datasets/polaris/clay_mean/clay_0_5",
             "sand": "projects/sat-io/open-datasets/polaris/sand_mean/sand_0_5",

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ AgriGEE.lite is organized into three main modules:
 | [Mapbiomas Brazil](https://brasil.mapbiomas.org/colecoes-mapbiomas/) | 37 Land Usage Land Cover Classes | 1985-01-01 | 2024-12-31 | Brazil | 30 | 1 year |  |
 | [ANADEM](https://hge-iph.github.io/anadem/) | Slope, Elevation, Aspect | (single image) | (single image) | South America | 30** | (single image) |  |
 | [SoilGrids classes](https://soilgrids.org/) | WRB Soil Classes (30 categories) | (single image) | (single image) | Worldwide | 250 | (single image) | |
+| POLARIS Soil Texture | Clay, Sand, Silt (0-5 cm), USDA Soil Class (12 categories) | (single image) | (single image) | Continental USA (CONUS) | 30 | (single image) | |
 | Two Satellite Fusion ***** | Intersect common observations from two satellites | (depends on input satellites) | (depends on input satellites) | (depends on input satellites) | (finest of the two satellites) | (depends on input satellites) | |
 
 ### Observations


### PR DESCRIPTION
- Add PolarisSoilTexture, a SingleImageSatellite source exposing POLARIS
  clay/sand/silt percentage bands (0-5 cm, CONUS, sat-io) and an optional
  derived usda_soil_class band via the 12-class USDA soil texture triangle
  expression.
- Register the class in agrigee_lite.sat (also picked up automatically by
  the REST API's satellite registry).
- Document the new source in the README and docs data-source tables.
#25 