### PR TITLE
fix: support SingleImageSatellite in POST /images download path

### DIFF
--- a/agrigee_lite/get/image.py
+++ b/agrigee_lite/get/image.py
@@ -250,6 +250,52 @@ async def _fetch_and_download_image(
             return chunk_index, False
 
 
+
+async def _download_single_image_zip_async(
+    satellite: SingleImageSatellite,
+    ee_feature: ee.Feature,
+    ee_geometry: ee.Geometry,
+    output_path: pathlib.Path,
+    force_redownload: bool,
+    max_retries_per_chunk: int,
+) -> list[str]:
+    """Download a static (time-independent) dataset as a single ZIP.
+
+    Static datasets have no time dimension, so the collection-resolution
+    machinery does not apply: resolve one download URL for the satellite's
+    single image and save it as ``<shortName>.zip`` in the cache dir.
+    """
+    image_name = satellite.shortName
+    file_path = output_path / f"{image_name}.zip"
+
+    if file_path.exists():
+        if not force_redownload:
+            return [image_name]
+        file_path.unlink()
+
+    output_path.mkdir(parents=True, exist_ok=True)
+    img = satellite.image(ee_feature).clip(ee_geometry)
+
+    async with aiohttp.ClientSession() as session:
+        async for attempt in AsyncRetrying(
+            stop=stop_after_attempt(max_retries_per_chunk),
+            wait=wait_exponential(multiplier=1, min=1, max=30),
+        ):
+            with attempt:
+                url = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        img.getDownloadURL,
+                        # Composited images (e.g. mosaic()) lose their source projection and
+                        # default to 1-degree scale on export — always pass the native scale.
+                        {"name": image_name, "region": ee_geometry, "scale": satellite.pixelSize},
+                    ),
+                    timeout=180,
+                )
+                await _download_url_to_path(session, url, file_path)
+
+    return [image_name]
+
+
 async def download_multiple_images_async(
     geometry: Polygon | MultiPolygon,
     start_date: pd.Timestamp | str,
@@ -301,6 +347,27 @@ async def download_multiple_images_async(
     geometry_wgs84 = transform_geometry(geometry, crs)
     ee_geometry = ee.Geometry(geometry_wgs84.__geo_interface__)
     ee_feature = ee.Feature(ee_geometry, {"s": start_date, "e": end_date, "0": 1})
+    if isinstance(satellite, SingleImageSatellite):
+        output_path = _compute_images_cache_dir(
+            satellite=satellite,
+            start_date=start_date,
+            end_date=end_date,
+            centroid_x=geometry_wgs84.centroid.x,
+            centroid_y=geometry_wgs84.centroid.y,
+            invalid_images_threshold=invalid_images_threshold,
+            image_indices=image_indices,
+            max_retries_per_chunk=max_retries_per_chunk,
+            crs=crs,
+        )
+        return await _download_single_image_zip_async(
+            satellite=satellite,
+            ee_feature=ee_feature,
+            ee_geometry=ee_geometry,
+            output_path=output_path,
+            force_redownload=force_redownload,
+            max_retries_per_chunk=max_retries_per_chunk,
+        )
+
     ee_expression = satellite.imageCollection(ee_feature)
 
     output_path = _compute_images_cache_dir(

--- a/agrigee_lite/sat/soil.py
+++ b/agrigee_lite/sat/soil.py
@@ -165,7 +165,7 @@ class PolarisSoilTexture(SingleImageSatellite):
                 f"Unknown band(s) for PolarisSoilTexture: {invalid}. Valid bands are {sorted(allowed_bands)}"
             )
 
-        super().__init__
+        super().__init__()
         self.imageNames: dict[str, str] = {
             "clay": "projects/sat-io/open-datasets/polaris/clay_mean/clay_0_5",
             "sand": "projects/sat-io/open-datasets/polaris/sand_mean/sand_0_5",


### PR DESCRIPTION
## Problem

`POST /images` fails for every `SingleImageSatellite` (all DEMs, `PolarisSoilTexture`, `WRBSoilClasses`) with:

```
ImageCollection.__init__() missing 1 required positional argument: 'args'
```

`download_multiple_images_async` unconditionally calls `satellite.imageCollection(ee_feature)`. Single-image classes implement `image()` instead, so the call lands on the `AbstractSatellite` stub, which returns `ee.ImageCollection()` with no arguments and raises.

## Fix

Static datasets have no time dimension, so none of the collection-resolution machinery (date filtering, `ZZ_USER_VALID_PIXELS` thresholding, per-date chunking) applies. The images path now branches before building the collection expression and resolves a single `getDownloadURL` ZIP, saved as `<shortName>.zip` in the same cache dir, with the same retry/timeout policy as the collection path. The job result's `dates` list contains `[shortName]`.

Two details worth flagging:

- **`scale=satellite.pixelSize` is passed explicitly.** Composited images (e.g. `USGS3DEP1m`, which does `ee.ImageCollection(...).mosaic()`) lose their source projection, and `getDownloadURL` then exports at the 1-degree default. Tested live: a ~415×445 m AOI returned a 667-byte raster without the scale argument, and a 558×446 px GeoTIFF at true 1 m with it.
- **`PolarisSoilTexture.__init__` called `super().__init__` without parentheses** — a no-op attribute access, so the base-class attributes were never initialized. Added the missing parens.

## Validation

Run against a live deployment (built from `main` @ d81299e + this patch), through the full REST flow (`POST /images` → poll `GET /jobs/{id}` → `GET /jobs/{id}/download`):

| Satellite | Result |
|---|---|
| `USGS3DEP1m` | 558×446 px GeoTIFF @ 1 m over ~415×445 m AOI |
| `PolarisSoilTexture` | 20×16 px @ 30 m, all four bands (clay/sand/silt/usda_soil_class) |
| `NAIP` (regression) | unchanged, still working |

🤖 Generated with [Claude Code](https://claude.com/claude-code)